### PR TITLE
fix Issue #7 - $.browser is deprecated

### DIFF
--- a/jquery.autoresize.js
+++ b/jquery.autoresize.js
@@ -34,9 +34,9 @@
         height = target.val('').height(),
         scroll = textarea.scrollHeight,
         offset = scroll > height ? (scroll - height) : 0;
-        target.data('minHeight', height);
         target.data('scrollOffset', offset);
-        $.browser.msie && target.css('overflow-y', 'hidden').scroll(function(){this.scrollTop = 0});
+        // Issue 6 - IE scrollbar flickering
+        target.css('overflow-y', 'hidden');
         return target.val(value);
     }
 
@@ -44,10 +44,7 @@
         target = $(this),
         targetHeight = target.height(),
         scrollOffset = target.data('scrollOffset'),
-        minHeight = target.data('minHeight'),
         scrollTop = frame.scrollTop(),
-        scrollHeight;
-        $.browser.msie || target.height(minHeight);
         scrollHeight = target.prop('scrollHeight') - scrollOffset;
         target.height(scrollHeight);
         frame.scrollTop(scrollTop);


### PR DESCRIPTION
- Refix Issue #6 properly.
- Always set `overflow-y: hidden;`, it avoids the flickering
  scrollbar on IE and is correct for other browsers as well.
- Don't set the target to minHeight before measuring,
  this causes heavy jumping for IE8, but seems to
  be totally unecessary.
- Also remove scroll(scrollTop = 0), testing didn't
  reveal any usefulness of this.

Tested with IE8, IE10, Chrome 31 and FF 26.0.
